### PR TITLE
Bump runtime to 21.08

### DIFF
--- a/com.github.matfantinel.moneta.json
+++ b/com.github.matfantinel.moneta.json
@@ -1,10 +1,10 @@
 {
   "app-id": "com.github.matfantinel.moneta",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "19.08",
+  "runtime-version": "21.08",
   "sdk": "org.freedesktop.Sdk",
   "base": "io.elementary.BaseApp",
-  "base-version": "juno-19.08",
+  "base-version": "juno-21.08",
   "command": "com.github.matfantinel.moneta",
   "finish-args": [
      "--share=ipc",
@@ -32,8 +32,7 @@
             {
                 "type": "git",
                 "url": "https://github.com/matfantinel/moneta.git",
-                "tag": "v2.2.0",
-                "commit": "52733301251e7e92c1d460054d7682de332c76d5"
+                "tag": "v2.2.0"
             },
             {
               "type" : "patch",


### PR DESCRIPTION
cc @matfantinel Please review when you have time. Thanks!

2.3.0 builds fine but doesn't launch, so I kept it at 2.2.0:

```
** (com.github.matfantinel.moneta:2): CRITICAL **: 07:10:06.601: Settings.vala:87: Could not connect: No such file or directory

** (com.github.matfantinel.moneta:2): CRITICAL **: 07:10:06.601: Settings.vala:107: Could not connect: No such file or directory
```